### PR TITLE
PR for fixing bugs in `scale_x` and `scale_y`

### DIFF
--- a/R/tools_ggplot2.R
+++ b/R/tools_ggplot2.R
@@ -62,13 +62,25 @@ get_scales <- function(panel_params) {
   listk(xlim, ylim)
 }
 
+# 2023-08-05, Yuxuan Xie
+# When the data contains `sf` objects, the structure of `panel`
+# will change and `panel_params` will not contain `x` and `y`,
+# but `x_range` and `y_range` instead.
 scale_x <- function(x, panel_params) {
-  lims <- panel_params$x$continuous_range
+  # the old version
+  # lims <- panel_params$x$continuous_range
+  x_name <- match.arg("x", names(panel_params))
+  if (x_name == "x") lims <- panel_params$x$continuous_range
+  if (x_name == "x_range") lims <- panel_params$x_range
   (x - lims[1]) / (lims[2] - lims[1])
 }
 
 scale_y <- function(y, panel_params) {
-  lims <- panel_params$y$continuous_range
+  # the old version
+  # lims <- panel_params$y$continuous_range
+  y_name <- match.arg("y", names(panel_params))
+  if (y_name == "y") lims <- panel_params$y$continuous_range
+  if (y_name == "y_range") lims <- panel_params$y_range
   (y - lims[1]) / (lims[2] - lims[1])
 }
 


### PR DESCRIPTION
老师您好：

我最近在使用`gg.layers`时遇到了一个错误。发现函数`geom_LatFreq`不能同时与如`geom_sf`或`geom_signHatch`等包含`sf`类对象的函数连用，原始脚本如下：

## 原始脚本

```R
library(dplyr)
library(ggplot2)
library(gg.layers)

d = AridityIndex
brks <- c(-Inf, 0.05, 0.2, 0.5, 0.65, 1:5, 20, Inf)
nbrk <- length(brks) - 1
cols <- rcolors::get_color("amwg256", nbrk) |> rev()

# test for geom_signHatch
d %<>% mutate(mask = z < 0.05)

ggplot(d) +
  geom_raster_filled(aes(x, y, z = z), breaks = brks, show.legend = F) +
  geom_latFreq(aes(y=y, z = z),
               options = list(is_spatial = T, zlim = c(-1, 1)*10),
               bbox = c(190, 240, -60, 90)) +
  geom_signHatch(aes(x, y, mask = mask), color='black') +
  layer_barchart(
    aes(x, y, z = z),
    width = unit(0.23, "npc"), height = unit(0.27, "npc"),
    theme = theme(
      plot.background = element_rect(fill ="white"),
      axis.text = element_text(size = 5.5, family="Times"),
      axis.title = element_blank()
    ),
    brks = brks, cols = cols, fact = 2
  ) +
  coord_sf(xlim = c(-180, 240), ylim = c(-60, 90), expand = FALSE, clip = "on") +
  scale_fill_manual(values =cols) +
  labs(x = NULL, y = NULL)
```

## 报错

```R
Error in `geom_latFreq()`:
! Problem while converting geom to grob.
i Error occurred in the 2nd layer.
Caused by error in `panel_params$x$continuous_range`:
! $ operator is invalid for atomic vectors
Run `rlang::last_trace()` to see where the error occurred.
Called from: signal_abort(cnd, .file)
Warning message:
Raster pixels are placed at uneven horizontal intervals and will be shifted
i Consider using `geom_tile()` instead. 
```

为此，我fork了库，发现了问题并“暂时”解决了它。

```R
# 2023-08-05, Yuxuan Xie
# When the data contains `sf` objects, the structure of `panel`
# will change and `panel_params` will not contain `x` and `y`,
# but `x_range` and `y_range` instead.
```

如果您有更好的修改建议可以对我的PR进行反馈。

感谢老师 : )